### PR TITLE
manual_weight_idx no longer dependent on n_bias_update

### DIFF
--- a/algorithm/core/utils/partial_backward.py
+++ b/algorithm/core/utils/partial_backward.py
@@ -72,8 +72,8 @@ def parsed_backward_config(backward_config, model):
                                                 if _is_pw1(all_convs[idx])]
 
     # sanity check: the weight update layers all update bias
-    for idx in backward_config['manual_weight_idx']:
-        assert idx in [n_conv - 1 - i_w for i_w in range(backward_config['n_bias_update'])]
+    # for idx in backward_config['manual_weight_idx']:
+    #     assert idx in [n_conv - 1 - i_w for i_w in range(backward_config['n_bias_update'])]
 
     n_weight_update = len(backward_config['manual_weight_idx'])
     if backward_config['weight_update_ratio'] is None:
@@ -86,7 +86,7 @@ def parsed_backward_config(backward_config, model):
         backward_config['weight_update_ratio'] = [float(p) for p in backward_config['weight_update_ratio'].split('-')]
         assert len(backward_config['weight_update_ratio']) == n_weight_update
     # if we update weights, let's also update bias
-    assert backward_config['n_bias_update'] >= n_weight_update
+    # assert backward_config['n_bias_update'] >= n_weight_update
     return backward_config
 
 
@@ -329,27 +329,30 @@ def apply_backward_config(model, backward_config):
     conv_ops = get_all_conv_ops(model)[::-1]
     ratio_ptr = len(backward_config['manual_weight_idx']) - 1
     for i_conv, conv in enumerate(conv_ops):  # back to front
-        if i_conv < backward_config['n_bias_update']:
-            real_idx = len(conv_ops) - i_conv - 1
-            train_this_conv = real_idx in backward_config['manual_weight_idx']
+        real_idx = len(conv_ops) - i_conv - 1
+        train_this_conv = real_idx in backward_config['manual_weight_idx']
 
-            if train_this_conv and backward_config['pw1_weight_only']:
-                assert _is_pw1(conv), conv
+        if train_this_conv and backward_config['pw1_weight_only']:
+            assert _is_pw1(conv), conv
 
-            if train_this_conv:
-                n_w_trained += 1
-                if backward_config['weight_update_ratio'][ratio_ptr] is not None:
-                    # apply sub channel gradient
-                    if _is_depthwise_conv(conv):
-                        conv.weight.grad.data = conv.weight.grad.data * conv.keep_mask.view(-1, 1, 1, 1)
-                    else:
-                        conv.weight.grad.data = conv.weight.grad.data * conv.keep_mask.view(1, -1, 1, 1)
-                    ratio_ptr -= 1
-            else:  # only update bias; no weight
+        # If this layer is in the backward config, we update the weights and biases
+        if train_this_conv:
+            n_w_trained += 1
+            if backward_config['weight_update_ratio'][ratio_ptr] is not None:
+                # apply sub channel gradient
+                if _is_depthwise_conv(conv):
+                    conv.weight.grad.data = conv.weight.grad.data * conv.keep_mask.view(-1, 1, 1, 1)
+                else:
+                    conv.weight.grad.data = conv.weight.grad.data * conv.keep_mask.view(1, -1, 1, 1)
+                ratio_ptr -= 1
+        else:
+            # If this layer is in bias update list, we update only the biases
+            if i_conv < backward_config['n_bias_update']:
                 conv.weight.grad = None
-        else:  # do not even update
-            conv.weight.grad = None
-            conv.bias.grad = None
+            # If this layer is in neither lists, we do not update it at all
+            else:
+                conv.weight.grad = None
+                conv.bias.grad = None
     assert n_w_trained == len(backward_config['manual_weight_idx']), \
         (n_w_trained, len(backward_config['manual_weight_idx']))
 

--- a/algorithm/core/utils/partial_backward.py
+++ b/algorithm/core/utils/partial_backward.py
@@ -339,20 +339,18 @@ def apply_backward_config(model, backward_config):
         if train_this_conv:
             n_w_trained += 1
             if backward_config['weight_update_ratio'][ratio_ptr] is not None:
-                # apply sub channel gradient
-                if _is_depthwise_conv(conv):
-                    conv.weight.grad.data = conv.weight.grad.data * conv.keep_mask.view(-1, 1, 1, 1)
+                if backward_config['weight_update_ratio'][ratio_ptr] != 0:
+                    # apply sub channel gradient
+                    if _is_depthwise_conv(conv):
+                        conv.weight.grad.data = conv.weight.grad.data * conv.keep_mask.view(-1, 1, 1, 1)
+                    else:
+                        conv.weight.grad.data = conv.weight.grad.data * conv.keep_mask.view(1, -1, 1, 1)
                 else:
-                    conv.weight.grad.data = conv.weight.grad.data * conv.keep_mask.view(1, -1, 1, 1)
+                    conv.weight.grad = None
                 ratio_ptr -= 1
         else:
-            # If this layer is in bias update list, we update only the biases
-            if i_conv < backward_config['n_bias_update']:
-                conv.weight.grad = None
-            # If this layer is in neither lists, we do not update it at all
-            else:
-                conv.weight.grad = None
-                conv.bias.grad = None
+            conv.weight.grad = None
+            conv.bias.grad = None
     assert n_w_trained == len(backward_config['manual_weight_idx']), \
         (n_w_trained, len(backward_config['manual_weight_idx']))
 

--- a/compilation/convert/pth2ir.py
+++ b/compilation/convert/pth2ir.py
@@ -121,17 +121,26 @@ def generated_backward_graph(mod, op_idx, method, sparse_bp_config=None, int8_bp
         total_convs = ir_scan_op(mod["main"])["nn.mcuconv2d"]
         # build sparse bp config
         sparse_op_idx = {}
+        # Keep track of biases
+        sparse_bias = []
+        # Ensure that we update the bias of the FC layer - always
+        sparse_bias.append(1)
         for idx, r in zip(
             sparse_bp_config["manual_weight_idx"],
             sparse_bp_config["weight_update_ratio"],
         ):
-            if r <= 0:
+            # Ignore negative ratios
+            if r < 0:
                 continue
-            sparse_op_idx[total_convs - idx] = r
+            # If ratio is non zero, sparse update
+            if r > 0:
+                sparse_op_idx[total_convs - idx] = r
+            # In all cases, update biases
+            sparse_bias.append(total_convs - idx)
 
         def get_sparse_bp_fn():
             tot_bias = sparse_bp_config["n_bias_update"]
-            bias_count = 0
+            bias_itr = 0
             tot_modules = total_convs
 
             def sparse_bp(var, grad_info):
@@ -145,12 +154,15 @@ def generated_backward_graph(mod, op_idx, method, sparse_bp_config=None, int8_bp
                     return False
                 idx = int(vname.split("_")[0].replace("v", ""))
                 # if (op_idx - idx) <= config["n_bias_update"] and "_bias" in vname:
-                nonlocal tot_bias, bias_count
+                nonlocal tot_bias, bias_itr
                 if "_bias" in vname:
-                    bias_count += 1
-                    if (tot_modules - bias_count) <= tot_bias:
+                    # IF this is present in the bias array, then we update the bias
+                    if (tot_modules - bias_itr) in sparse_bias:
+                        bias_itr += 1
                         return True
+                    # If not present in the bias array, look at the next element
                     else:
+                        bias_itr += 1
                         return False
                 if is_sparse and "_weight" in vname:
                     return True


### PR DESCRIPTION
Assume we have to update layer 25, 37 and 39. At present, such an update scheme would require the updating of the biases of the last 18 layers. However if in terms of energy, a better solution could be just updating 8 biases. 
This fix allows the training of the weights of layers 25, 37 and 39, the bias of the last 18 layers and the the bias of layer 25.